### PR TITLE
fix sql/streaming benchmarks, use environment in env.sh

### DIFF
--- a/MatrixFactorization/bin/gen_data.sh
+++ b/MatrixFactorization/bin/gen_data.sh
@@ -31,7 +31,7 @@ res=$?;
 END_TIME=`timestamp`
 SIZE=`${DU} -s ${INPUT_HDFS} | awk '{ print $1 }'`
 get_config_fields >> ${BENCH_REPORT}
-print_config  ${APP}-gen ${START_TIME} ${END_TIME} ${SIZE} ${START_TS} ${res}>> ${BENCH_REPORT};
+print_config  ${APP}-gen ${START_TIME} ${END_TIME} ${SIZE:-0} ${START_TS} ${res}>> ${BENCH_REPORT};
 teardown
 
 exit 0

--- a/MatrixFactorization/bin/run.sh
+++ b/MatrixFactorization/bin/run.sh
@@ -31,7 +31,7 @@ for((i=0;i<${NUM_TRIALS};i++)); do
 
     END_TIME=`timestamp`
     get_config_fields >> ${BENCH_REPORT}
-    print_config  ${APP} ${START_TIME} ${END_TIME} ${SIZE} ${START_TS} ${res}>> ${BENCH_REPORT};
+    print_config  ${APP} ${START_TIME} ${END_TIME} ${SIZE:-0} ${START_TS} ${res}>> ${BENCH_REPORT};
 done
 teardown
 exit 0

--- a/SQL/bin/config.sh
+++ b/SQL/bin/config.sh
@@ -24,8 +24,25 @@ APP_MASTER=${SPARK_MASTER}
 set_gendata_opt
 set_run_opt
 
-#input benreport
 function print_config(){
+get_config_values $1 $2 $3 $4 $5 $6
+}
+
+function get_config_fields(){
+local report_field=$(get_report_field_name)
+echo -n "#${report_field},AppType,numV,numPar,mu,sigma,iter,tol,reset_prob"
+echo -en "\n"
+
+}
+function get_config_values(){
+gen_report $1 $2 $3 $4 $5 $6
+echo -n ",${APP}-MLlibConfig,${numV},${NUM_OF_PARTITIONS},${mu},${sigma},${MAX_ITERATION},${TOLERANCE},${RESET_PROB}"
+echo -en "\n"
+return 0
+}
+
+#output results + extended config details
+function print_extended_config(){
 	local output=$1
 
 	CONFIG=

--- a/SQL/bin/gen_data.sh
+++ b/SQL/bin/gen_data.sh
@@ -34,8 +34,9 @@ res=$?;
 END_TIME=`timestamp`
 
 SIZE=`${DU} -s ${INPUT_HDFS} | awk '{ print $1 }'`
-#get_config_fields >> ${BENCH_REPORT}
-print_config  ${APP} ${START_TIME} ${END_TIME} ${SIZE} ${START_TS} ${res}>> ${BENCH_REPORT};
+get_config_fields >> ${BENCH_REPORT}
+print_config  ${APP}-gen ${START_TIME} ${END_TIME} ${SIZE} ${START_TS} ${res}>> ${BENCH_REPORT};
+print_extended_config ${APP}-gen-with-config
 teardown
 exit 0
 

--- a/SQL/bin/run.sh
+++ b/SQL/bin/run.sh
@@ -36,8 +36,9 @@ START_TS=`get_start_ts`;
 	exec ${SPARK_HOME}/bin/spark-submit --class $CLASS --master ${APP_MASTER} ${YARN_OPT} ${SPARK_OPT} ${SPARK_RUN_OPT} $JAR ${OPTION} 2>&1|tee $logf
 res=$?;
 	END_TIME=`timestamp`
-#get_config_fields >> ${BENCH_REPORT}
+get_config_fields >> ${BENCH_REPORT}
 print_config  ${APP} ${START_TIME} ${END_TIME} ${SIZE} ${START_TS} ${res}>> ${BENCH_REPORT};
+print_extended_config ${APP}-with-config
 done
 teardown
 exit 0

--- a/Streaming/bin/config.sh
+++ b/Streaming/bin/config.sh
@@ -9,7 +9,7 @@ if [ -f "${bin}/../conf/env.sh" ]; then
 fi
 
 APP=streaming
-INPUT_HDFS=${DATA_HDFS}/LinearRegression/Input
+INPUT_HDFS=${DATA_HDFS}/${APP}/Input
 OUTPUT_HDFS=${DATA_HDFS}/${APP}/Output
 if [ ${COMPRESS_GLOBAL} -eq 1 ]; then
     INPUT_HDFS=${INPUT_HDFS}-comp
@@ -22,8 +22,24 @@ APP_MASTER=${SPARK_MASTER}
 set_gendata_opt
 set_run_opt
 
-#input benreport
 function print_config(){
+get_config_values $1 $2 $3 $4 $5 $6
+}
+
+function get_config_fields(){
+local report_field=$(get_report_field_name)
+echo -n "#${report_field}"
+echo -en "\n"
+
+}
+function get_config_values(){
+gen_report $1 $2 $3 $4 $5 $6
+echo -en "\n"
+return 0
+}
+
+#output results + extended config details
+function print_extended_config(){
 	local output=$1
 
 	CONFIG=

--- a/Streaming/bin/gen_data.sh
+++ b/Streaming/bin/gen_data.sh
@@ -41,7 +41,7 @@ if [ $subApp = "StreamingLogisticRegression" ];then
 
 
 		START_TIME=`timestamp`
-		START_TS=`ssh ${master} "date +%F-%T"`
+		START_TS=`get_start_ts`
 
 		${HADOOP_HOME}/bin/hdfs dfs -rm -r  ${trainingDir}/*
 		tmpdir=${INPUT_HDFS}/tmp-train
@@ -69,7 +69,7 @@ res=$?;
 		END_TIME=`timestamp`
 		sleep 5
 get_config_fields >> ${BENCH_REPORT}
-print_config  ${APP} ${START_TIME} ${END_TIME} ${SIZE} ${START_TS} ${res}>> ${BENCH_REPORT};
+print_config  ${APP} ${START_TIME} ${END_TIME} ${SIZE:-0} ${START_TS} ${res}>> ${BENCH_REPORT};
 	done
 
 	exit 0
@@ -145,7 +145,8 @@ START_TS=`get_start_ts`;
 res=$?;
 	END_TIME=`timestamp`
 get_config_fields >> ${BENCH_REPORT}
-print_config  ${APP} ${START_TIME} ${END_TIME} ${SIZE} ${START_TS} ${res}>> ${BENCH_REPORT};
+print_config  ${APP} ${START_TIME} ${END_TIME} ${SIZE:-0} ${START_TS} ${res}>> ${BENCH_REPORT};
+print_extended_config ${APP}-gen-with-config
 done
 teardown
 exit 0

--- a/Streaming/bin/run.sh
+++ b/Streaming/bin/run.sh
@@ -13,7 +13,7 @@ SIZE=`${DU} -s ${INPUT_HDFS} | awk '{ print $1 }'`
 
 
 JAR="${SPARK_HOME}/examples/target/scala-2.10/spark-examples-${SPARK_VERSION}-hadoop2.7.1.jar"
-if [[ -z "$JAR" ]]; then
+if [[ ! -f "$JAR" ]]; then
   echo "Failed to find Spark examples assembly in  ${SPARK_HOME}/examples/target" 1>&2
   echo "You need to build Spark before running this program" 1>&2
   exit 1
@@ -98,7 +98,8 @@ START_TS=`get_start_ts`;
 res=$?;
 	END_TIME=`timestamp`
 get_config_fields >> ${BENCH_REPORT}
-print_config  ${APP} ${START_TIME} ${END_TIME} ${SIZE} ${START_TS} ${res}>> ${BENCH_REPORT};
+print_config  ${APP} ${START_TIME} ${END_TIME} ${SIZE:-0} ${START_TS} ${res}>> ${BENCH_REPORT};
+print_extended_config ${APP}-with-config
 done
 teardown
 exit 0

--- a/bin/funcs.sh
+++ b/bin/funcs.sh
@@ -57,19 +57,24 @@ function check_dir() {
 }
 #usage purge_date "${MC_LIST}"
 function purge_data(){
-	local mc_list="$1"	
-	cmd="echo 3 >/proc/sys/vm/drop_caches"; 
-	#echo ${mc_list}
-	for nn in ${mc_list}; do 
-	#echo $nn
-	ssh  -t $nn "sudo sh -c \"$cmd\""; 
-	done;
-	echo "data purged on ${mc_list}"
+    local mc_list="$1"
+    cmd="echo 3 2>/dev/null >/proc/sys/vm/drop_caches || echo 'cannot drop caches inside a container'"
+    if [ -n "$mc_list" ]; then
+        # drop caches on workers
+        for nn in ${mc_list}; do
+            #echo $nn
+            ssh  -t $nn "sudo sh -c \"$cmd\""
+        done
+        echo "data purged on ${mc_list}"
+    else
+        # drop caches on local (standalone)
+        sudo sh -c "$cmd"
+        echo "data purged on local"
+    fi
 }
 function get_start_ts() {
-#   ts=`ssh ${master} "date +%F-%T"`
-   ts=`date +%F-%T`
-   echo $ts
+    ts=`date +%F-%T`
+    echo $ts
 }
 function setup(){
   if [ "${MASTER}" = "spark" ] && [ "${RESTART}" = "TRUE" ] ; then

--- a/conf/env.sh
+++ b/conf/env.sh
@@ -1,11 +1,12 @@
 # global settings
 
+# HDFS master
 master="hdfs-master-0"
 #A list of machines where the spark cluster is running
-MC_LIST="plugin-0"
-sparkmaster="plugin-0"
-export SPARK_HOME=/usr/lib/spark
-export HADOOP_HOME=/usr/lib/hadoop
+MC_LIST=`hostname`
+sparkmaster=`hostname`
+[ -z "$SPARK_HOME" ] && export SPARK_HOME=/usr/lib/spark
+[ -z "$HADOOP_HOME" ] && export HADOOP_HOME=/usr/lib/hadoop
 export PATH="$PATH:$HADOOP_HOME/bin"
 
 # base dir for DataSet
@@ -13,7 +14,10 @@ HDFS_URL="hdfs://${master}:8020"
 SPARK_HADOOP_FS_LOCAL_BLOCK_SIZE=536870912
 
 # base dir in HDFS for data ingestion & output
-DATA_HDFS="${HDFS_URL}/spark-bench"
+# Remote HDFS
+#DATA_HDFS="${HDFS_URL}/spark-bench"
+# Local HDFS
+DATA_HDFS="hdfs:///user/ubuntu/spark-bench"
 
 
 #Local dataset dir where preloaded datasets resides
@@ -27,7 +31,8 @@ SPARK_VERSION=1.4.1  #1.4.0
 #SPARK_MASTER=local[K]
 #SPARK_MASTER=local[*]
 #SPARK_MASTER=yarn-client
-SPARK_MASTER=spark://${sparkmaster}:7077
+#SPARK_MASTER=spark://${sparkmaster}:7077
+SPARK_MASTER=${MASTER}
 
 # host running generator for PageView Streaming App
 PAGEVIEW_GEN=${sparkmaster}
@@ -48,14 +53,12 @@ SPARK_KRYOSERIALIZER_BUFFER_MAX=2047m
 # - SPARK_STORAGE_MEMORYFRACTION, --conf spark.storage.memoryfraction
 SPARK_STORAGE_MEMORYFRACTION=0.5
 #export MEM_FRACTION_GLOBAL=0.005
-SPARK_EXECUTOR_MEMORY=200g
-SPARK_DRIVER_MEMORY=10g
 
 # Spark options in YARN client mode
 # - SPARK_DRIVER_MEMORY, --driver-memory
 # - SPARK_EXECUTOR_INSTANCES, --num-executors
 # - SPARK_EXECUTOR_CORES, --executor-cores
-# - SPARK_DRIVER_MEMORY, --driver-memory
+# - SPARK_EXECUTOR_MEMORY, --executor-memory
 export EXECUTOR_GLOBAL_MEM=40G
 export executor_cores=6
 


### PR DESCRIPTION
This PR updates sql and streaming benchmarks so that they print results to ./num/bench-report.dat like the other benchmarks.  Without this, these benchmark results aren't easy to find.

I also updated the environment so it does not explicitly set DRIVER / EXECUTOR_MEMORY.  These values are already set in the environment (e.g. spark-env.sh).

These changes are being used in this Juju bundle and have been tested successfully on both intel and power machines:

https://jujucharms.com/u/bigdata-dev/apache-hdfs-spark-standalone/7
